### PR TITLE
Fix TX_BUSY when not using an explicit tx_intr_pin

### DIFF
--- a/components/MCP2518FD/MCP2518.cpp
+++ b/components/MCP2518FD/MCP2518.cpp
@@ -305,7 +305,7 @@ bool MCP2518_FAST_PATH MCP2518::IsTxAvailable(uint8_t fifo_index) const
         return !_tx_fifo_full;
     }
     Registers::C1TXIF reg { readRegister(reg.address) };
-    return !reg.IsInterruptPending(fifo_index);
+    return reg.IsInterruptPending(fifo_index);
 }
 
 bool MCP2518::IsCANError() const


### PR DESCRIPTION
The fallback logic for checking the TX readiness when no TX INT pin is defined appears to have been inverted. This behavior only shows when using GPIO_NUM_NC for .tx_intr_pin.

IsInterruptPending(...) effectively checks the C1TXIF register interrupt. As far as I can tell, the condition to send should be when the interrupt is ACTIVE as that indicates TX ready. 

I inverted the logic and it fixed the TX_BUSY errors. Please let me know if my brief diagnosis and datasheet glance are incorrect.